### PR TITLE
#1780 dependencies

### DIFF
--- a/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
+++ b/code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml
@@ -27,12 +27,10 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/langchain4j-chroma/pom.xml
+++ b/langchain4j-chroma/pom.xml
@@ -32,12 +32,10 @@
             <artifactId>converter-gson</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/langchain4j-cohere/pom.xml
+++ b/langchain4j-cohere/pom.xml
@@ -30,12 +30,10 @@
             <artifactId>converter-jackson</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/langchain4j-hugging-face/pom.xml
+++ b/langchain4j-hugging-face/pom.xml
@@ -37,12 +37,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/langchain4j-mistral-ai/pom.xml
+++ b/langchain4j-mistral-ai/pom.xml
@@ -35,7 +35,6 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
@@ -45,7 +44,6 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp-sse</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/langchain4j-nomic/pom.xml
+++ b/langchain4j-nomic/pom.xml
@@ -35,13 +35,10 @@
         <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/langchain4j-ollama/pom.xml
+++ b/langchain4j-ollama/pom.xml
@@ -39,12 +39,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-parent/pom.xml
+++ b/langchain4j-parent/pom.xml
@@ -131,28 +131,6 @@
                 <version>${retrofit.version}</version>
             </dependency>
 
-            <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
-
-            <!-- To resolve version conflicts inside the 'okhttp' library, we are excluding the transitive -->
-            <!-- dependencies causing version divergence errors and including them explicitly. This ensures a consistent -->
-            <!-- version to be used in the project and satisfies Maven Enforcer requirements to avoid version divergence -->
-            <!-- in the project. -->
-
-            <!-- Please check whether version conflicts are gone after upgrading  this library as this will make it -->
-            <!-- possible to remove these exclusions and explicit inclusions below. -->
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp-sse</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-
-
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-bom</artifactId>
@@ -175,12 +153,19 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp-bom</artifactId>
+                <version>${okhttp.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
 
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>mockwebserver</artifactId>
                 <version>${okhttp.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -193,12 +178,15 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
+                <scope>provided</scope>
             </dependency>
 
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
+                <artifactId>slf4j-bom</artifactId>
                 <version>${slf4j-api.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>
@@ -251,9 +239,10 @@
 
             <dependency>
                 <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
+                <artifactId>assertj-bom</artifactId>
                 <version>${assertj.version}</version>
-                <scope>test</scope>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
 
             <dependency>

--- a/langchain4j-vespa/pom.xml
+++ b/langchain4j-vespa/pom.xml
@@ -56,12 +56,10 @@
             <artifactId>converter-gson</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/langchain4j-voyage-ai/pom.xml
+++ b/langchain4j-voyage-ai/pom.xml
@@ -30,12 +30,10 @@
             <artifactId>converter-jackson</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/langchain4j-workers-ai/pom.xml
+++ b/langchain4j-workers-ai/pom.xml
@@ -34,12 +34,10 @@
             <artifactId>converter-jackson</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml
@@ -38,12 +38,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
+++ b/web-search-engines/langchain4j-web-search-engine-tavily/pom.xml
@@ -39,12 +39,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (START) -->
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
-        <!-- DEPENDENCY CONFLICT RESOLUTION FOR OKHTTP (END)  -->
 
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
This pull request involves the removal of redundant comments and the restructuring of dependency management for `okhttp` across multiple `pom.xml` files in the project. The changes aim to simplify the dependency configuration and ensure consistency.

Dependency management improvements:

* Removed comments related to dependency conflict resolution for `okhttp` in various `pom.xml` files, as they were no longer necessary (`code-execution-engines/langchain4j-code-execution-engine-judge0/pom.xml`, `langchain4j-chroma/pom.xml`, `langchain4j-cohere/pom.xml`, `langchain4j-hugging-face/pom.xml`, `langchain4j-mistral-ai/pom.xml`, `langchain4j-nomic/pom.xml`, `langchain4j-ollama/pom.xml`, `langchain4j-vespa/pom.xml`, `langchain4j-voyage-ai/pom.xml`, `langchain4j-workers-ai/pom.xml`, `web-search-engines/langchain4j-web-search-engine-searchapi/pom.xml`, `web-search-engines/langchain4j-web-search-engine-tavily/pom.xml`). [[1]](diffhunk://#diff-56cad95cf408c606497257920f4f7da0a8bdfec99ea0362dd706e15f65a3b368L30-L35) [[2]](diffhunk://#diff-cf88a44aeef4fb469afb808aa18a06def2aaeac397b2343fd4f6eeaa52649d71L35-L40) [[3]](diffhunk://#diff-f92b301a2f8ba7a31f1f53aa638b4d368380b41a922e9bdb86579976dee2c212L33-L38) [[4]](diffhunk://#diff-9339b3c52aaf693b6be19ba1b6e52e1b5471b822792cfa8e6ee85115cc339057L40-L45) [[5]](diffhunk://#diff-7c5a5de3182ef0d374bd6e588488e05e8c002fa1e4512aabec973be810bc9945L38) [[6]](diffhunk://#diff-df83989f8d57b4411be8d35afee07b1c022f8431a301789d8f570167f49703bbL38-L45) [[7]](diffhunk://#diff-cc2a3a38b598f3738c546aa8c6818a8df1717c5f45cc855231e5055d40c70e0fL42-L47) [[8]](diffhunk://#diff-26f0b2b52d3e6f807717b98085042c7daa9635fb4b72656d3ddb5abd3c4ea8d9L59-L64) [[9]](diffhunk://#diff-f9da72646ddcd3e686b1992d8a2ddbc4cf36efbc13556fea6f8f532a1dd0272fL33-L38) [[10]](diffhunk://#diff-5f37408d9bed9b3dfc5c16778a0191ae369214c33c80c5cea7e2589b55e4c045L37-L42) [[11]](diffhunk://#diff-6af3825b22cfc6bb64d619a25a1d4bbca43d6290cc73febf6961a44a2667d94bL41-L46) [[12]](diffhunk://#diff-c1c976408f2576592626e4220dece66a35ba2ccfe1eaf2009dbed2b631a147b6L42-L47)
* Consolidated `okhttp` dependency management by using the `okhttp-bom` for consistent versioning and simplified dependency declarations in `langchain4j-parent/pom.xml`. [[1]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L134-L155) [[2]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L178-R168)
* Updated the scope and type for certain dependencies to ensure proper usage and avoid conflicts in `langchain4j-parent/pom.xml`. [[1]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0R181-R189) [[2]](diffhunk://#diff-db1dfc1ccffac6c8f8ae2414e6aad535940aaf08a488d30941157dc53ec573b0L254-R245)